### PR TITLE
tests: add playwright e2e tests

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -48,3 +48,4 @@ Thumbs.db
 tslint-result.txt
 prettier-result.txt
 .angular
+playwright-report

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,15 +25,15 @@ You can check if the code is properly formatted using `yarn format:check`.
 
 ## Unit tests
 
-`ng test` lauches a Chrome headless browser instead of an actual Chrome browser. 
+`ng test` launches a Chrome headless browser instead of an actual Chrome browser. 
 
 You can still debug a test by launching the browser by yourself and going to `http://localhost:9876`.
 
 ## End-to-end tests
 
-The support for end-to-end tests using Protractor has been removed. If we end up writing end-to-end
-tests, using [Cypress](https://www.cypress.io/) (installed using the [Cypress schematic](https://github.com/briebug/cypress-schematic))
-would be a better option.
+`yarn e2e` runs the end-to-end tests.
+Playwright is used, using its own server.
+See `playwright.config.ts` for more options.
 
 # Compiling and Linting
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -59,6 +59,14 @@
               ],
               "outputHashing": "all"
             },
+            "e2e": {
+              "fileReplacements": [
+                {
+                  "replace": "src/app/shared/authentication.service.ts",
+                  "with": "src/app/shared/authentication-e2e.service.ts"
+                }
+              ]
+            },
             "development": {
               "buildOptimizer": false,
               "optimization": false,
@@ -82,6 +90,10 @@
             },
             "development": {
               "browserTarget": "rare-basket-frontend:build:development"
+            },
+            "e2e": {
+              "browserTarget": "rare-basket-frontend:build:e2e",
+              "port": 4202
             }
           },
           "defaultConfiguration": "development"

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -40,6 +40,13 @@ tasks {
         outputs.dir("coverage")
     }
 
+    val yarnE2e by registering(YarnTask::class) {
+        args.set(listOf("e2e"))
+        dependsOn(prepare)
+        inputs.dir("src")
+        outputs.dir("playwright-report")
+    }
+
     val yarnLint by registering(YarnTask::class){
         args.set(listOf("lint"))
         dependsOn(prepare)
@@ -57,9 +64,14 @@ tasks {
         dependsOn(yarnTest)
     }
 
+    val e2e by registering {
+        dependsOn(yarnE2e)
+    }
+
     check {
         dependsOn(lint)
         dependsOn(test)
+        dependsOn(e2e)
     }
 
     assemble {
@@ -69,5 +81,6 @@ tasks {
     val clean by getting {
         dependsOn("cleanYarnBuild")
         dependsOn("cleanYarnTest")
+        dependsOn("cleanYarnE2e")
     }
 }

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,16 @@
+# E2E tests using Playwright
+
+Run `yarn e2e` to run the tests
+
+Arguments can be passed to the last command. See details at https://playwright.dev/docs/test-cli.
+
+In particular:
+
+- to run a single test file: `yarn e2e e2e/the-test-file.spec.ts`
+- to run with just chromium: `yarn e2e --project=chromium`
+- to run with headed browsers (i.e. visible windows): `yarn e2e --headed`
+- to run just one test, in chromium only, in headed mode: `yarn e2e e2e/the-test-file.spec.ts --project=chromium --headed`
+- to run step by step: `yarn e2e e2e/the-test-file.spec.ts --project=chromium --debug`
+
+To be able to skip some parts in debug mode, add `await page.pause();` to the test, where you want to pause.
+

--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Home', () => {
+  test('should display a welcome message', async ({ page }) => {
+    await page.goto('/rare-basket/');
+    await expect(page.locator('h2')).toHaveText('Welcome admin');
+    await expect(page.locator('#orders-link')).toHaveText('Orders');
+  });
+});

--- a/frontend/e2e/orders.spec.ts
+++ b/frontend/e2e/orders.spec.ts
@@ -1,0 +1,74 @@
+import { expect, Page, test } from '@playwright/test';
+
+const inProgressNinjaSquadOrder = {
+  id: 952,
+  basket: {
+    reference: 'OMGVJPNK',
+    rationale: null as string,
+    customer: {
+      name: 'Ninja Squad',
+      organization: null as string,
+      email: 'contact@ninja-squad.com',
+      deliveryAddress: '13 lot les Tilleuls, 42170 ST JUST ST RAMBERT',
+      billingAddress: '13 lot les Tilleuls, 42170 ST JUST ST RAMBERT',
+      type: 'FR_COMPANY',
+      language: 'fr'
+    },
+    confirmationInstant: '2022-09-30T19:23:30.191702Z'
+  },
+  status: 'DRAFT',
+  items: [] as Array<unknown>,
+  documents: [] as Array<unknown>
+};
+export const inProgressOrders = (page: Page) =>
+  page.route('**/api/orders?status=DRAFT&page=0', route => {
+    route.fulfill({
+      body: JSON.stringify({ content: [inProgressNinjaSquadOrder], totalElements: 1, totalPages: 1, size: 20, number: 0 })
+    });
+  });
+
+export const postOrder = (page: Page) =>
+  page.route('**/api/orders', route => {
+    route.fulfill({
+      body: JSON.stringify(inProgressNinjaSquadOrder)
+    });
+  });
+
+export const getOrder = (page: Page) =>
+  page.route('**/api/orders/952', route => {
+    route.fulfill({
+      body: JSON.stringify(inProgressNinjaSquadOrder)
+    });
+  });
+
+test.describe('Orders', () => {
+  test('should display in progress orders', async ({ page }) => {
+    // api call to get the "in progress" orders
+    await inProgressOrders(page);
+    // api call to get an order
+    await getOrder(page);
+    // api call to create a new order
+    await postOrder(page);
+
+    await page.goto('/rare-basket/orders');
+    await expect(page.locator('h1')).toHaveText('Orders');
+    await expect(page.locator('a.active')).toHaveText('In progress');
+
+    // one order in progress
+    await expect(page.locator('text=1 order(s) in progress')).toBeVisible();
+    await expect(page.locator('text=OMGVJPNK')).toBeVisible();
+
+    // create an order
+    await page.locator('text=Create an order').click();
+    await page.locator('text=Customer name').fill('Ninja Squad');
+    await page.locator('text=Customer email').fill('contact@ninja-squad.com');
+    await page.locator('text=Delivery address of the customer').fill('13 lot les Tilleuls, 42170 ST JUST ST RAMBERT');
+    await page.locator('text=Use the delivery address as the billing address').check();
+    await page.locator('text=Customer category').selectOption({ label: 'French private company' });
+    await page.locator('text=Preferred language of the customer').selectOption({ label: 'French' });
+    await page.locator('text=Save').click();
+
+    // accession selection
+    await expect(page.locator('h1')).toContainText('Order OMGVJPNK');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,13 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start:e2e": "ng serve --configuration=e2e",
     "build": "ng build --no-progress",
     "test": "ng test --code-coverage --no-progress --no-watch",
     "lint": "mkdir -p build && ng lint > build/eslint-result.txt",
-    "format": "prettier --write \"{src,e2e}/**/*.+(ts|js|json|html|scss)\""
+    "format": "prettier --write \"{src,e2e}/**/*.+(ts|js|json|html|scss)\"",
+    "e2e": "yarn playwright test",
+    "postinstall": "npx playwright install"
   },
   "private": true,
   "dependencies": {
@@ -24,6 +27,7 @@
     "@fortawesome/free-solid-svg-icons": "6.2.0",
     "@ng-bootstrap/ng-bootstrap": "13.0.0",
     "@ngx-translate/core": "14.0.0",
+    "@playwright/test": "1.26.1",
     "@popperjs/core": "2.11.6",
     "angular-auth-oidc-client": "14.1.5",
     "bootstrap": "5.2.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,72 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './e2e',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 10000
+  },
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI ? 'list' : 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    baseURL: 'http://localhost:4202'
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome']
+      }
+    },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox']
+      }
+    }/*,
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari']
+      }
+    }*/
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  outputDir: 'e2e/test-results/',
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run start:e2e',
+    port: 4202,
+    reuseExistingServer: !process.env.CI
+  },
+};
+
+export default config;

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -11,7 +11,7 @@ import { ValdemortModule } from 'ngx-valdemort';
 import { ValidationDefaultsComponent } from './validation-defaults/validation-defaults.component';
 import { I18nModule } from './i18n/i18n.module';
 import { AbstractSecurityStorage, AuthModule, StsConfigLoader } from 'angular-auth-oidc-client';
-import { AuthenticationConfigService, authFactory, CustomSecurityStorage } from './shared/authentication.service';
+import { AuthenticationConfigService, authFactory, CustomSecurityStorage } from './shared/authentication-config.service';
 import { AuthenticationInterceptorService } from './shared/authentication-interceptor.service';
 import { NavbarComponent } from './navbar/navbar.component';
 import { ErrorInterceptorService } from './shared/error-interceptor.service';

--- a/frontend/src/app/shared/authentication-config.service.ts
+++ b/frontend/src/app/shared/authentication-config.service.ts
@@ -1,0 +1,102 @@
+import { Inject, Injectable } from '@angular/core';
+import {
+  AbstractSecurityStorage,
+  AuthWellKnownEndpoints,
+  LogLevel,
+  OpenIdConfiguration,
+  StsConfigStaticLoader
+} from 'angular-auth-oidc-client';
+import { WINDOW } from './window.service';
+import { LocationStrategy } from '@angular/common';
+import { environment } from '../../environments/environment';
+
+const CONFIG_ID = 'rare-basket-auth';
+
+/**
+ * We use local storage instead of the default local storage, otherwise we can't even open
+ * a link in a new tab without losing authentication
+ */
+@Injectable()
+export class CustomSecurityStorage extends AbstractSecurityStorage {
+  constructor() {
+    super();
+  }
+
+  read(key: string): any {
+    const item = localStorage.getItem(key);
+    if (!item) {
+      return null;
+    }
+
+    return JSON.parse(item);
+  }
+
+  write(key: string, value: any): void {
+    value = value || null;
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+
+  remove(key: string): void {
+    localStorage.removeItem(key);
+  }
+
+  clear() {
+    // apparently, only read and write are actually used, and always with the same key: the config ID
+    // to be safe, let's at least removed that key
+    localStorage.removeItem(CONFIG_ID);
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthenticationConfigService {
+  constructor(@Inject(WINDOW) private window: Window, private locationStrategy: LocationStrategy) {}
+
+  getConfig(): OpenIdConfiguration {
+    // create the configuration
+    const keycloakUrl = environment.keycloakUrl;
+    const url = this.window.origin + this.locationStrategy.getBaseHref();
+
+    const realmPath = environment.realmPath;
+    const realmUrl = `${keycloakUrl}${realmPath}`;
+    const authWellknownEndpoints: AuthWellKnownEndpoints = {
+      // these properties can be obtained from
+      // http://localhost:8082/auth/realms/rare-basket/.well-known/openid-configuration
+      // which is the URL of the link "OpenID Endpoint Configuration" in the "Realm Settings" page of the
+      // Keycloak web console
+      issuer: realmUrl,
+      jwksUri: `${realmUrl}/protocol/openid-connect/certs`,
+      authorizationEndpoint: `${realmUrl}/protocol/openid-connect/auth`,
+      tokenEndpoint: `${realmUrl}/protocol/openid-connect/token`,
+      userInfoEndpoint: `${realmUrl}/protocol/openid-connect/userinfo`,
+      endSessionEndpoint: `${realmUrl}/protocol/openid-connect/logout`,
+      checkSessionIframe: `${realmUrl}/protocol/openid-connect/login-status-iframe.html`,
+      introspectionEndpoint: `${realmUrl}/protocol/openid-connect/token/introspect`
+    };
+
+    return {
+      configId: CONFIG_ID,
+      authority: keycloakUrl,
+      redirectUrl: url,
+      clientId: 'rare-basket',
+      responseType: 'code',
+      scope: 'openid offline_access', // offline_access is required by the aidc library if silent renew is true
+      postLogoutRedirectUri: url,
+      startCheckSession: false,
+      silentRenew: true,
+      triggerAuthorizationResultEvent: true,
+      logLevel: LogLevel.Warn,
+      maxIdTokenIatOffsetAllowedInSeconds: 10,
+      useRefreshToken: true,
+      ignoreNonceAfterRefresh: true,
+      autoUserInfo: false,
+      authWellknownEndpoints
+    };
+  }
+}
+
+export const authFactory = (authenticationConfigService: AuthenticationConfigService) => {
+  const config = authenticationConfigService.getConfig();
+  return new StsConfigStaticLoader(config);
+};

--- a/frontend/src/app/shared/authentication-e2e.service.ts
+++ b/frontend/src/app/shared/authentication-e2e.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { Observable, ReplaySubject } from 'rxjs';
+import { User } from './user.model';
+import { map } from 'rxjs/operators';
+
+/**
+ * This is a "fake" authentication service used in the e2e tests,
+ * to avoid messing around keycloack.
+ * It always returns a logged in user (admi, with all permissions).
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthenticationService {
+  // Use a ReplaySubject and not a BehaviorSubject so that the authentication guard waits until the login is done
+  // and the user is loaded before asking to login
+  private currentUser = new ReplaySubject<User | null>(1);
+
+  /**
+   * Initializes the authentication system based on OpenID/Connect.
+   * This is called by the app module constructor and should never be called anywhere else
+   */
+  init() {
+    this.currentUser.next({
+      id: 1,
+      name: 'admin',
+      permissions: ['ADMINISTRATION', 'ORDER_MANAGEMENT', 'ORDER_VISUALIZATION'],
+      globalVisualization: true,
+      visualizationGrcs: [],
+      accessionHolder: {
+        id: 1,
+        name: 'CBGP',
+        email: 'contact1@grc1.fr',
+        grc: { id: 1, name: 'GRC1', address: '10 rue du Louvres 75000 Paris', institution: 'INRAE' },
+        phone: ''
+      }
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
+  login(requestedUrl = '/') {}
+
+  logout() {
+    this.currentUser.next(null);
+  }
+
+  isAuthenticated(): Observable<boolean> {
+    return this.getCurrentUser().pipe(map(u => !!u));
+  }
+
+  getCurrentUser(): Observable<User | null> {
+    return this.currentUser.asObservable();
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1632,6 +1632,14 @@
     read-package-json-fast "^2.0.3"
     which "^2.0.2"
 
+"@playwright/test@1.26.1":
+  version "1.26.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.26.1.tgz#73ada4e70f618bca69ba7509c4ba65b5a41c4b10"
+  integrity sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.26.1"
+
 "@popperjs/core@2.11.6":
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
@@ -5418,6 +5426,11 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.26.1:
+  version "1.26.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.26.1.tgz#a162f476488312dcf12638d97685144de6ada512"
+  integrity sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==
 
 postcss-attribute-case-insensitive@^5.0.2:
   version "5.0.2"


### PR DESCRIPTION
Adds a simple e2e tests for the orders

To avoid messing with keycloack authent, I added a fake authentications service, replaced by the CLI in the e2e configuration used to run the tests.

Fixes #116 