### PR TITLE
feat: allow breaking the identifier of an accession in the middle

### DIFF
--- a/frontend/src/app/shared/accession/accession.component.html
+++ b/frontend/src/app/shared/accession/accession.component.html
@@ -1,1 +1,1 @@
-{{ accession.name }} <small class="text-muted">{{ accession.identifier }}</small>
+{{ accession.name }} <small class="text-muted" style="word-break: break-word">{{ accession.identifier }}</small>


### PR DESCRIPTION
faidare identifiers are huge strings without spaces, so in order for that to look not too bad, the identifier needs to be broken in the middle