### PR TITLE
fix: use animation instead of spin input for fa-icon

### DIFF
--- a/frontend/src/app/order/export-orders/export-orders.component.html
+++ b/frontend/src/app/order/export-orders/export-orders.component.html
@@ -14,7 +14,7 @@
     <div class="col-12 mt-2 mt-sm-0">
       <button type="submit" [disabled]="exporting" class="btn btn-primary" id="export-button">
         @if (exporting) {
-          <fa-icon [icon]="exportingIcon" [spin]="true" class="me-1" id="export-spinner"></fa-icon>
+          <fa-icon [icon]="exportingIcon" [animation]="'spin'" class="me-1" id="export-spinner"></fa-icon>
         }
         <span translate="order.export-orders.export"></span>
       </button>

--- a/frontend/src/app/order/order/order.component.html
+++ b/frontend/src/app/order/order/order.component.html
@@ -119,7 +119,7 @@
                   >
                     {{ document.originalFileName }}
                     @if (isDownloading(document)) {
-                      <fa-icon [icon]="downloadingIcon" [spin]="true" class="ms-1 download-spinner"></fa-icon>
+                      <fa-icon [icon]="downloadingIcon" [animation]="'spin'" class="ms-1 download-spinner"></fa-icon>
                     }
                   </button>
                 </div>


### PR DESCRIPTION
`spin` is deprecated and removed in v0.15